### PR TITLE
Bump versions, add a namespace, remove record? predicate

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject backtick "0.3.0"
+(defproject backtick "0.3.1"
   :description "Provides the syntax-quote reader macro as a normal macro"
   :url "https://github.com/brandonbloom/backtick"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/src/backtick.clj
+++ b/src/backtick.clj
@@ -22,9 +22,6 @@
 (defn unquote-splicing? [form]
   (and (seq? form) (= (first form) 'clojure.core/unquote-splicing)))
 
-(defn record? [x]
-  (instance? clojure.lang.IRecord x))
-
 (defn- quote-fn* [form]
   (cond
     (symbol? form) `'~(resolve form)


### PR DESCRIPTION
- Bumped version of clojure specified to 1.6.0
- Bumped version of backtick to 0.3.1
- Removed `record?` definition as it now exists in clojure 1.6.0
