### PR TITLE
Fixes multiple consecutive splicing unquotes

### DIFF
--- a/src/backtick.clj
+++ b/src/backtick.clj
@@ -30,10 +30,10 @@
     (record? form) `'~form
     (coll? form)
       (let [xs (if (map? form) (apply concat form) form)
-            parts (for [x (partition-by unquote-splicing? xs)]
-                    (if (unquote-splicing? (first x))
-                      (second (first x))
-                      (mapv quote-fn* x)))
+            parts (for [x xs]
+                    (if (unquote-splicing? x)
+                      (second x)
+                      [(quote-fn* x)]))
             cat (doall `(concat ~@parts))]
         (cond
           (vector? form) `(vec ~cat)

--- a/test/backtick_test.clj
+++ b/test/backtick_test.clj
@@ -9,6 +9,11 @@
       (is (=           `(5 nil () true a/b ~n [p/q ~@v r/s] {:x #{"s"}})
               (template (5 nil () true a/b ~n [p/q ~@v r/s] {:x #{"s"}}))))))
 
+  (testing "Multiple splices"
+    (let [v [:a :b] a 5]
+      (is (=           `(~a ~@v ~@v ~a)
+             (template  (~a ~@v ~@v ~a))))))
+
   (testing "Automatic gensyms"
     (let [[a b c d] (template [foo# bar# foo# bar])]
       (is (not= a 'foo))


### PR DESCRIPTION
I noticed that multiple consecutive splicing unquotes don't get expanded.

```clj
(testing "Multiple splices"
    (let [v [:a :b]]
      (is (=           `(~@v ~@v)
             (template  (~@v ~@v))))))
; FAIL in clojure.lang.PersistentList$EmptyList@1 (backtick_test.clj:14)
; Multiple splices
; expected: (= (clojure.core/seq (clojure.core/concat v v)) (template ((clojure.core/unquote-splicing v) (clojure.core/unquote-splicing v))))
;   actual: (not (= (:a :b :a :b) (:a :b)))
; false
```

Here is a fix for that.
I guess this is not as efficient as previous version as it's creating unnecessary vector for each normal unquote. If you think this is not good enough I have some ideas about using recur or reduce.