### PR TITLE
0.3.5: Custom expanders

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject backtick "0.3.4"
+(defproject backtick "0.3.5"
   :description "Provides the syntax-quote reader macro as a normal macro"
   :url "https://github.com/brandonbloom/backtick"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject backtick "0.3.3"
+(defproject backtick "0.3.4"
   :description "Provides the syntax-quote reader macro as a normal macro"
   :url "https://github.com/brandonbloom/backtick"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]])
+  :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/src/backtick.clj
+++ b/src/backtick.clj
@@ -1,14 +1,15 @@
-(ns backtick
-  (:refer-clojure :exclude [resolve]))
+(ns backtick)
 
-(def ^:dynamic *resolve*)
+(def ^:dynamic *qualify*)
+
+(def ^:dynamic *expand*)
 
 (def ^:dynamic ^:private *gensyms*)
 
-(defn error [msg form]
+(defn- error [msg form]
   (throw (ex-info msg {:form form})))
 
-(defn- resolve [sym]
+(defn- qualify [sym]
   (let [ns (namespace sym)
         n (name sym)]
     (if (and (not ns) (= (last n) \#))
@@ -17,7 +18,7 @@
         (let [gs (gensym (str (subs n 0 (dec (count n))) "__auto__"))]
           (swap! *gensyms* assoc sym gs)
           gs))
-      (*resolve* sym))))
+      (*qualify* sym))))
 
 (defn unquote? [form]
   (and (seq? form) (= (first form) 'clojure.core/unquote)))
@@ -44,43 +45,51 @@
         cat (doall `(concat ~@parts))]
     (cond
       (vector? coll) `(vec ~cat)
-      (map? coll) `(apply hash-map ~cat)
-      (set? coll) `(set ~cat)
-      (seq? coll) `(apply list ~cat)
-      :else (error "Unknown collection type" coll))))
+      (map? coll)    `(apply hash-map ~cat)
+      (set? coll)    `(set ~cat)
+      (seq? coll)    `(apply list ~cat)
+      :else           (error "Unknown collection type" coll))))
 
 (defn quote-items [coll]
   ((cond
      (vector? coll) vec
-     (map? coll) #(into {} %)
-     (set? coll) set
-     (seq? coll) #(list* 'list (doall %))
-     :else (error "Unknown collection type" coll))
+     (map? coll)    #(into {} %)
+     (set? coll)    set
+     (seq? coll)    #(list* 'list (doall %))
+     :else          (error "Unknown collection type" coll))
    (map quote-fn* coll)))
 
 (defn- quote-fn* [form]
   (cond
-    (inert? form) form
-    (symbol? form) `'~(resolve form)
-    (unquote? form) (second form)
+    (inert? form)            form
+    (symbol? form)           `'~(qualify form)
+    (unquote? form)          (second form)
     (unquote-splicing? form) (error "splice not in collection" form)
-    (record? form) `'~form
-    (coll? form) (if (some unquote-splicing? form)
-                   (splice-items form)
-                   (quote-items form))
-    :else `'~form))
+    (record? form)           `'~form
+    (coll? form)             (if (some unquote-splicing? form)
+                               (splice-items form)
+                               (quote-items form))
+    :else                    `'~form))
 
-(defn quote-fn [resolver form]
-  (binding [*resolve* resolver
-            *gensyms* (atom {})]
-    (quote-fn* form)))
+(defn quote-fn
+  ([qualifier expander]
+   (quote-fn qualifier identity expander))
+  ([qualifier expander form]
+    (binding [*qualify* qualifier
+              *expand* expander
+              *gensyms* (atom {})]
+      (quote-fn* form))))
 
-(defmacro defquote [name resolver]
-  `(let [resolver# ~resolver]
-     (defn ~(symbol (str name "-fn")) [form#]
-       (quote-fn resolver# form#))
-     (defmacro ~name [form#]
-       (quote-fn resolver# form#))))
+(defmacro defquote
+  ([name qualifier]
+   `(defquote ~name ~qualifier identity))
+  ([name qualifier expander]
+    `(let [qualifier# ~qualifier
+           expander#  ~expander]
+       (defn ~(symbol (str name "-fn")) [form#]
+         (quote-fn qualifier# expander# form#))
+       (defmacro ~name [form#]
+         (quote-fn qualifier# expander# form#)))))
 
 (defquote template identity)
 
@@ -99,30 +108,30 @@
 (defn- var-symbol [^clojure.lang.Var v]
   (symbol (var-namespace v) (var-name v)))
 
-(defn- ns-resolve-sym [sym]
+(defn- ns-qualify [sym]
   (try
     (let [x (ns-resolve *ns* sym)]
       (cond
-        (instance? java.lang.Class x) (class-symbol x)
+        (instance? java.lang.Class x)  (class-symbol x)
         (instance? clojure.lang.Var x) (var-symbol x)
         :else nil))
     (catch ClassNotFoundException _
       sym)))
 
-(defn resolve-symbol [sym]
+(defn qualify-symbol [sym]
   (let [ns (namespace sym)
         nm (name sym)]
     (if (nil? ns)
       (if-let [[_ ctor-name] (re-find #"(.+)\.$" nm)]
         (symbol nil (-> (symbol nil ctor-name)
-                      resolve-symbol
+                      qualify-symbol
                       name
                       (str ".")))
         (if (or (special-symbol? sym)
                 (re-find #"^\." nm)) ; method name
           sym
-          (or (ns-resolve-sym sym)
+          (or (ns-qualify sym)
               (symbol (namespace-name *ns*) nm))))
-      (or (ns-resolve-sym sym) sym))))
+      (or (ns-qualify sym) sym))))
 
-(defquote syntax-quote resolve-symbol)
+(defquote syntax-quote qualify-symbol)

--- a/test/backtick_test.clj
+++ b/test/backtick_test.clj
@@ -1,6 +1,6 @@
 (ns backtick-test
   (:use clojure.test)
-  (:require [backtick :refer (template defquote quote-fn syntax-quote)]))
+  (:require [backtick :refer (template defquote syntax-quote quote-fn)]))
 
 (deftest template-test
 

--- a/test/backtick_test.clj
+++ b/test/backtick_test.clj
@@ -57,7 +57,7 @@
     (is (= ''ABBREVIATED  (quote-fn identity the-map '~a)))
     (is (= ''ABBREVIATED (wacky-quote-fn the-map '~a)))
     (is (= '(ABBREVIATED :a [5 bar!])
-           (abbrev-quote (ABBREVIATED :a [5 bar!]))))))
+           (abbrev-quote (~a :a [5 bar!]))))))
 
 (defrecord R [x])
 

--- a/test/backtick_test.clj
+++ b/test/backtick_test.clj
@@ -28,7 +28,7 @@
     (is (= '["ax" "bx" "cx"] (template #(str % \x)         [~a ~b ~c])))
     (let [x 1
           e (try (eval '(backtick/template #(str % x) [~a]))
-              (catch ExceptionInfo e
+              (catch Exception e
                 e))]
       (is (instance? ExceptionInfo e))
       (is (= (str "Error evaluating templating expander of 'template' "
@@ -43,7 +43,7 @@
 (def the-map
   '{a 'ABBREVIATED})
 
-(defquote map-quote identity the-map)
+(defquote abbrev-quote identity the-map)
 
 (deftest defquote-test
 
@@ -57,7 +57,7 @@
     (is (= ''ABBREVIATED  (quote-fn identity the-map '~a)))
     (is (= ''ABBREVIATED (wacky-quote-fn the-map '~a)))
     (is (= '(ABBREVIATED :a [5 bar!])
-           (map-quote (ABBREVIATED :a [5 bar!]))))))
+           (abbrev-quote (ABBREVIATED :a [5 bar!]))))))
 
 (defrecord R [x])
 


### PR DESCRIPTION
From the updated README:

> You can also define a templating macro with a custom expander, which is run only
on expanded expressions (and conversely a qualifier only runs on unexpanded expressions).
> 
> It can be used to let the expanded expressions refer to something else than the
> lexical scope so as to fill the placeholders with the content of a map for
> instance.
> 
> ```clojure
> (defquote abbrev-quote identity '{b 'bar})
> 
> (abbrev-quote {:foo ~b})
> 
> ;; Prints at the REPL:
> {:foo bar}
> ```
> 
> It is also possible to override the expander of a templating macro (by default,
> `identity`) by specifying it at the call site.
> 
> ```clojure
> (def abbreviations
>   '{b 'bar})
> 
> (template abbreviations {:foo ~b})
> 
> ;; Prints at the REPL:
> {:foo bar}
> ```

I published these modifications @ `[org.clojars.tristefigure/backtick "0.3.5"]`