### PR TITLE
Add metadata support for collections

### DIFF
--- a/src/backtick.clj
+++ b/src/backtick.clj
@@ -29,18 +29,19 @@
     (unquote-splicing? form) (throw (Exception. "splice not in list"))
     (record? form) `'~form
     (coll? form)
-      (let [xs (if (map? form) (apply concat form) form)
-            parts (for [x xs]
-                    (if (unquote-splicing? x)
-                      (second x)
-                      [(quote-fn* x)]))
-            cat (doall `(concat ~@parts))]
-        (cond
-          (vector? form) `(vec ~cat)
-          (map? form) `(apply hash-map ~cat)
-          (set? form) `(set ~cat)
-          (seq? form) `(apply list ~cat)
-          :else (throw (Exception. "Unknown collection type"))))
+    (let [xs (if (map? form) (apply concat form) form)
+          parts (for [x xs]
+                  (if (unquote-splicing? x)
+                    (second x)
+                    [(quote-fn* x)]))
+          cat (doall `(concat ~@parts))
+          m (meta form)]
+      (cond
+        (vector? form) `(with-meta (vec ~cat) (quote ~m))
+        (map? form) `(with-meta (apply hash-map ~cat) (quote ~m))
+        (set? form) `(with-meta (set ~cat) (quote ~m))
+        (seq? form) `(with-meta (apply list ~cat) (quote ~m))
+        :else (throw (Exception. "Unknown collection type"))))
     :else `'~form))
 
 (defn quote-fn [resolver form]
@@ -90,9 +91,9 @@
     (if (nil? ns)
       (if-let [[_ ctor-name] (re-find #"(.+)\.$" nm)]
         (symbol nil (-> (symbol nil ctor-name)
-                      resolve-symbol
-                      name
-                      (str ".")))
+                        resolve-symbol
+                        name
+                        (str ".")))
         (if (or (special-symbol? sym)
                 (re-find #"^\." nm)) ; method name
           sym

--- a/src/backtick.clj
+++ b/src/backtick.clj
@@ -35,13 +35,15 @@
                     (second x)
                     [(quote-fn* x)]))
           cat (doall `(concat ~@parts))
-          m (meta form)]
-      (cond
-        (vector? form) `(with-meta (vec ~cat) (quote ~m))
-        (map? form) `(with-meta (apply hash-map ~cat) (quote ~m))
-        (set? form) `(with-meta (set ~cat) (quote ~m))
-        (seq? form) `(with-meta (apply list ~cat) (quote ~m))
-        :else (throw (Exception. "Unknown collection type"))))
+          coll (cond
+                 (vector? form) `(vec ~cat)
+                 (map? form) `(apply hash-map ~cat)
+                 (set? form) `(set ~cat)
+                 (seq? form) `(apply list ~cat)
+                 :else (throw (Exception. "Unknown collection type")))]
+      (if-some [m (meta form)]
+        `(with-meta ~coll (quote ~m))
+        coll))
     :else `'~form))
 
 (defn quote-fn [resolver form]

--- a/test/backtick_test.clj
+++ b/test/backtick_test.clj
@@ -7,12 +7,12 @@
   (testing "Primitives, collections, unquote, and splice; symbols qualified"
     (let [n 5 v [:a :b]]
       (is (=           `(5 nil () true a/b ~n [p/q ~@v r/s] {:x #{"s"}})
-              (template (5 nil () true a/b ~n [p/q ~@v r/s] {:x #{"s"}}))))))
+                       (template (5 nil () true a/b ~n [p/q ~@v r/s] {:x #{"s"}}))))))
 
   (testing "Multiple splices"
     (let [v [:a :b] a 5]
       (is (=           `(~a ~@v ~@v ~a)
-             (template  (~a ~@v ~@v ~a))))))
+                       (template  (~a ~@v ~@v ~a))))))
 
   (testing "Automatic gensyms"
     (let [[a b c d] (template [foo# bar# foo# bar])]
@@ -43,18 +43,18 @@
 (deftest syntax-quote-test
   (testing "Constructors, classes, methods, vars, and specials"
     (is (= (syntax-quote
-             [Class
-              Class.
-              java.lang.Class
-              java.lang.Class.
-              unqualified
-              fully/qualified
-              .method
-              .
-              non.existant
-              inc
-              backtick.test/inc
-              quote])
+            [Class
+             Class.
+             java.lang.Class
+             java.lang.Class.
+             unqualified
+             fully/qualified
+             .method
+             .
+             non.existant
+             inc
+             backtick.test/inc
+             quote])
            `[Class
              Class.
              java.lang.Class
@@ -67,3 +67,7 @@
              inc
              backtick.test/inc
              quote]))))
+
+(deftest preserves-collection-metadata
+  (is (= '{:tag x/y}
+         (meta (template ^x/y [1 2 3])))))


### PR DESCRIPTION
A better solution for metadata and collections in general would probably use something like:

  `(into (quote ~empty-coll) ~cat)

where empty-coll is computed during macro expansion.  This would both preserve metadata and be a gateway to less brittle support for all collection types.

But element order is reversed for lists and this complicates things beyond the scope of this pull request.